### PR TITLE
Use milliseconds to display timer results

### DIFF
--- a/lib/perf_timer.dart
+++ b/lib/perf_timer.dart
@@ -8,6 +8,7 @@ class TimerNotFoundException implements Exception {
 // Perf timer
 class PerfTimer {
   static bool devOnly = true;
+  static bool useMilliseconds = true;
   static bool isDev = (() {
     bool isDev = false;
 
@@ -112,14 +113,22 @@ class PerfTimer {
         percentsString = percents.toStringAsFixed(2);
       }
 
-      str += '\n$percentsString% $label$value';
+      String valueStr = value.toString();
+      if (useMilliseconds == true) {
+        valueStr = (value / 1000).toStringAsFixed(2) + " ms";
+      }
+      str += '\n$percentsString% $label$valueStr';
       return str;
     });
 
     final dotsCount = longestLabelLength - totalLabel.length + 3;
     final dots = '.' * dotsCount;
 
-    result += '\n\n${' ' * 7}$totalLabel$dots$totalTime';
+    String totalTimeStr = totalTime.toString();
+    if (useMilliseconds == true) {
+      totalTimeStr = (totalTime / 1000).toStringAsFixed(2) + " ms";
+    }
+    result += '\n\n${' ' * 7}$totalLabel$dots$totalTimeStr';
 
     return result;
   }

--- a/lib/perf_timer.dart
+++ b/lib/perf_timer.dart
@@ -8,7 +8,7 @@ class TimerNotFoundException implements Exception {
 // Perf timer
 class PerfTimer {
   static bool devOnly = true;
-  static bool useMilliseconds = true;
+  static bool useMicroseconds = false;
   static bool isDev = (() {
     bool isDev = false;
 
@@ -114,7 +114,7 @@ class PerfTimer {
       }
 
       String valueStr = value.toString();
-      if (useMilliseconds == true) {
+      if (useMicroseconds == false) {
         valueStr = (value / 1000).toStringAsFixed(2) + " ms";
       }
       str += '\n$percentsString% $label$valueStr';
@@ -125,7 +125,7 @@ class PerfTimer {
     final dots = '.' * dotsCount;
 
     String totalTimeStr = totalTime.toString();
-    if (useMilliseconds == true) {
+    if (useMicroseconds == false) {
       totalTimeStr = (totalTime / 1000).toStringAsFixed(2) + " ms";
     }
     result += '\n\n${' ' * 7}$totalLabel$dots$totalTimeStr';

--- a/lib/perf_timer.dart
+++ b/lib/perf_timer.dart
@@ -113,10 +113,11 @@ class PerfTimer {
         percentsString = percents.toStringAsFixed(2);
       }
 
-      String valueStr = value.toString();
-      if (useMicroseconds == false) {
-        valueStr = (value / 1000).toStringAsFixed(2) + " ms";
-      }
+      String valueStr;
+      useMicroseconds
+          ? valueStr = value.toString()
+          : valueStr = (value / 1000).toStringAsFixed(2) + " ms";
+
       str += '\n$percentsString% $label$valueStr';
       return str;
     });
@@ -124,10 +125,12 @@ class PerfTimer {
     final dotsCount = longestLabelLength - totalLabel.length + 3;
     final dots = '.' * dotsCount;
 
-    String totalTimeStr = totalTime.toString();
-    if (useMicroseconds == false) {
-      totalTimeStr = (totalTime / 1000).toStringAsFixed(2) + " ms";
-    }
+    String totalTimeStr;
+
+    useMicroseconds
+        ? totalTimeStr = totalTime.toString()
+        : totalTimeStr = (totalTime / 1000).toStringAsFixed(2) + " ms";
+
     result += '\n\n${' ' * 7}$totalLabel$dots$totalTimeStr';
 
     return result;


### PR DESCRIPTION
Hi. I found that the microseconds in results are not very human readable and changed this to use milliseconds by default. There is still and option to use microseconds.